### PR TITLE
add lower bound filter option

### DIFF
--- a/xpublish_wms/query.py
+++ b/xpublish_wms/query.py
@@ -184,6 +184,10 @@ class WMSGetMapQuery(WMSBaseQuery):
         False,
         description="Whether to automatically scale the color scale range based on the data. When specified, colorscalerange is ignored",
     )
+    transparent_below_range: bool = Field(
+        False,
+        description="Whether to render values below the colorscalerange as transparent instead of clamping to the first colormap value",
+    )
 
     @field_validator("colorscalerange", mode="before")
     @classmethod
@@ -351,6 +355,7 @@ WMS_FILTERED_QUERY_PARAMS = {
     "height",
     "colorscalerange",
     "autoscale",
+    "transparent_below_range",
     "item",
     "day",
     "range",

--- a/xpublish_wms/wms/get_map.py
+++ b/xpublish_wms/wms/get_map.py
@@ -214,6 +214,7 @@ class GetMap:
 
         self.colorscalerange = query.colorscalerange
         self.autoscale = query.autoscale
+        self.transparent_below_range = query.transparent_below_range
 
         available_selectors = ds.gridded.additional_coords(ds[self.parameter])
         self.dim_selectors = {
@@ -508,6 +509,11 @@ class GetMap:
                 tris,
             )
         logger.debug(f"WMS GetMap Mesh time: {time.time() - start_mesh}")
+        
+        if self.transparent_below_range and not self.autoscale and self.colorscalerange:
+            min_threshold = self.colorscalerange[0]
+            mesh = mesh.where(mesh >= min_threshold)
+        
         custom_palettename = self.palettename.split(',')
         start_shade = time.time()
         shaded = tf.shade(


### PR DESCRIPTION
This adds a quick and simple filter for values below our color range, which will allow us to address https://github.com/carbonplan/ocr-web/issues/9